### PR TITLE
Install missing php7-fileinfo extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache --update \
     php7-ctype \
     php7-curl \
     php7-fpm \
+    php7-fileinfo \
     php7-gd \
     php7-iconv \
     php7-intl \


### PR DESCRIPTION
Hi ya :raising_hand_man: 

When trying to run the docker setup on the 2.4 branch it failed with an error:
```
Changed current directory to /home/www-data/.composer
./composer.json has been created
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing hirak/prestissimo (0.3.7): Downloading (100%)         
Writing lock file
Generating autoload files
Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for intervention/image 2.4.1 -> satisfiable by intervention/image[2.4.1].
    - intervention/image 2.4.1 requires ext-fileinfo * -> the requested PHP extension fileinfo is missing from your system.
  Problem 2
    - intervention/image 2.4.1 requires ext-fileinfo * -> the requested PHP extension fileinfo is missing from your system.
    - laravolt/avatar 1.8.1 requires intervention/image ^2.1 -> satisfiable by intervention/image[2.4.1].
    - Installation request for laravolt/avatar 1.8.1 -> satisfiable by laravolt/avatar[1.8.1].

  To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php7/php.ini
    - /etc/php7/conf.d/00_bcmath.ini
    - /etc/php7/conf.d/00_ctype.ini
    - /etc/php7/conf.d/00_curl.ini
    - /etc/php7/conf.d/00_dom.ini
    - /etc/php7/conf.d/00_gd.ini
    - /etc/php7/conf.d/00_iconv.ini
    - /etc/php7/conf.d/00_intl.ini
    - /etc/php7/conf.d/00_json.ini
    - /etc/php7/conf.d/00_mbstring.ini
    - /etc/php7/conf.d/00_mcrypt.ini
    - /etc/php7/conf.d/00_opcache.ini
    - /etc/php7/conf.d/00_openssl.ini
    - /etc/php7/conf.d/00_pdo.ini
    - /etc/php7/conf.d/00_posix.ini
    - /etc/php7/conf.d/00_session.ini
    - /etc/php7/conf.d/00_simplexml.ini
    - /etc/php7/conf.d/00_soap.ini
    - /etc/php7/conf.d/00_tokenizer.ini
    - /etc/php7/conf.d/00_xml.ini
    - /etc/php7/conf.d/00_zip.ini
    - /etc/php7/conf.d/00_zlib.ini
    - /etc/php7/conf.d/01_mysqlnd.ini
    - /etc/php7/conf.d/01_pdo_pgsql.ini
    - /etc/php7/conf.d/01_pdo_sqlite.ini
    - /etc/php7/conf.d/01_phar.ini
    - /etc/php7/conf.d/02_pdo_mysql.ini
    - /etc/php7/conf.d/20_redis.ini
    - /etc/php7/conf.d/apcu.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.
ERROR: Service 'cachet' failed to build: The command '/bin/sh -c wget https://github.com/cachethq/Cachet/archive/${cachet_ver}.tar.gz &&     tar xzvf ${cachet_ver}.tar.gz --strip-components=1 &&     chown -R www-data:root /var/www/html &&     rm -r ${cachet_ver}.tar.gz &&     php /bin/composer.phar global require "hirak/prestissimo:^0.3" &&     php /bin/composer.phar install --no-dev -o &&     rm -rf bootstrap/cache/*' returned a non-zero code: 2
```

This PR should install the missing extension.